### PR TITLE
feat(payment): add PaymentScreen to handle payment processing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import HomeScreen from '@/screens/HomeScreen';
 import ProductDetailScreen from '@/screens/ProductDetailScreen';
 import FavoriteScreen from '@/screens/FavoriteScreen';
 import CartScreen from '@/screens/CartScreen';
+import PaymentScreen from '@/screens/PaymentScreen';
 import {CartProvider} from '@/context/CartContext';
 import {FavoriteProvider} from '@/context/FavoriteContext';
 import {
@@ -13,6 +14,7 @@ import {
   PRODUCT_DETAIL_SCREEN,
   FAVORITE_SCREEN,
   CART_SCREEN,
+  PAYMENT_SCREEN,
 } from '@/constant';
 
 const Stack = createStackNavigator();
@@ -33,6 +35,7 @@ function App(): React.JSX.Element {
             />
             <Stack.Screen name={FAVORITE_SCREEN} component={FavoriteScreen} />
             <Stack.Screen name={CART_SCREEN} component={CartScreen} />
+            <Stack.Screen name={PAYMENT_SCREEN} component={PaymentScreen} />
           </Stack.Navigator>
         </NavigationContainer>
       </CartProvider>

--- a/src/screens/PaymentScreen.tsx
+++ b/src/screens/PaymentScreen.tsx
@@ -1,0 +1,288 @@
+import React, {useState} from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+  StatusBar,
+  Alert,
+  Platform,
+} from 'react-native';
+import {StackNavigationProp} from '@react-navigation/stack';
+import {useCart} from '@/context/CartContext';
+import {CART_SCREEN, PAYMENT_SCREEN} from '@/constant';
+import type {RootStackParamList} from '@/types';
+
+type PaymentScreenProps = {
+  navigation: StackNavigationProp<RootStackParamList, typeof PAYMENT_SCREEN>;
+};
+
+function PaymentScreen({navigation}: PaymentScreenProps) {
+  const {cartItems, removeSelectedItems} = useCart();
+  const [selectedPayment, setSelectedPayment] = useState<string>('');
+
+  const selectedItems = cartItems.filter(item => item.isSelected);
+  const subtotal = selectedItems.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0,
+  );
+  const tax = subtotal * 0.1;
+  const shipping = 10;
+  const total = subtotal + tax + shipping;
+
+  const paymentMethods = [
+    {
+      id: 'credit_card',
+      name: 'Credit Card',
+      icon: require('@/assets/icons/credit-card.png'),
+    },
+    {
+      id: 'paypal',
+      name: 'PayPal',
+      icon: require('@/assets/icons/paypal.png'),
+    },
+    {
+      id: 'google_pay',
+      name: 'Google Pay',
+      icon: require('@/assets/icons/google-pay.png'),
+    },
+  ];
+
+  const handlePayment = () => {
+    if (!selectedPayment) {
+      Alert.alert('Error', 'Please select a payment method');
+      return;
+    }
+
+    Alert.alert(
+      'Confirm Payment',
+      `Total payment: $${total.toFixed(2)}`,
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel',
+        },
+        {
+          text: 'Confirm',
+          onPress: () => {
+            Alert.alert('Success', 'Payment processed successfully!');
+            removeSelectedItems();
+            navigation.navigate(CART_SCREEN);
+          },
+        },
+      ],
+      {cancelable: false},
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle="light-content" backgroundColor="#0A0A0F" />
+      <ScrollView style={styles.container}>
+        <Text style={styles.title}>Payment Details</Text>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Selected Items</Text>
+          {selectedItems.map(item => (
+            <View key={item.id} style={styles.itemContainer}>
+              <View style={styles.imageContainer}>
+                <Image
+                  source={{uri: item.thumbnail}}
+                  style={styles.itemImage}
+                />
+              </View>
+              <View style={styles.itemDetails}>
+                <Text style={styles.itemName}>{item.title}</Text>
+                <Text style={styles.itemPrice}>
+                  ${item.price} x {item.quantity}
+                </Text>
+              </View>
+              <Text style={styles.itemTotal}>
+                ${(item.price * item.quantity).toFixed(2)}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Payment Method</Text>
+          {paymentMethods.map(method => (
+            <TouchableOpacity
+              key={method.id}
+              style={[
+                styles.paymentMethod,
+                selectedPayment === method.id && styles.selectedPayment,
+              ]}
+              onPress={() => setSelectedPayment(method.id)}>
+              <Image source={method.icon} style={styles.paymentIcon} />
+              <Text style={styles.paymentText}>{method.name}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Order Summary</Text>
+          <View style={styles.summaryItem}>
+            <Text style={styles.summaryLabel}>Subtotal</Text>
+            <Text style={styles.summaryValue}>${subtotal.toFixed(2)}</Text>
+          </View>
+          <View style={styles.summaryItem}>
+            <Text style={styles.summaryLabel}>Tax (10%)</Text>
+            <Text style={styles.summaryValue}>${tax.toFixed(2)}</Text>
+          </View>
+          <View style={styles.summaryItem}>
+            <Text style={styles.summaryLabel}>Shipping</Text>
+            <Text style={styles.summaryValue}>${shipping.toFixed(2)}</Text>
+          </View>
+          <View style={[styles.summaryItem, styles.totalItem]}>
+            <Text style={styles.totalLabel}>Total</Text>
+            <Text style={styles.totalValue}>${total.toFixed(2)}</Text>
+          </View>
+        </View>
+      </ScrollView>
+
+      <View style={styles.bottomBar}>
+        <TouchableOpacity style={styles.payButton} onPress={handlePayment}>
+          <Text style={styles.payButtonText}>Pay Now</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#0A0A0F',
+    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
+  },
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
+    marginBottom: 24,
+  },
+  section: {
+    marginBottom: 24,
+    padding: 16,
+    backgroundColor: '#1A1A1A',
+    borderRadius: 12,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#FFFFFF',
+    marginBottom: 16,
+  },
+  itemContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  itemDetails: {
+    flex: 1,
+  },
+  itemName: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    marginBottom: 4,
+  },
+  itemPrice: {
+    color: '#888',
+    fontSize: 14,
+  },
+  itemTotal: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  paymentMethod: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    backgroundColor: '#2D2D2D',
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  selectedPayment: {
+    backgroundColor: '#6200EE',
+  },
+  paymentIcon: {
+    width: 24,
+    height: 24,
+    marginRight: 12,
+  },
+  paymentText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+  },
+  summaryItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  summaryLabel: {
+    color: '#888',
+    fontSize: 16,
+  },
+  summaryValue: {
+    color: '#FFFFFF',
+    fontSize: 16,
+  },
+  totalItem: {
+    marginTop: 12,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#333',
+  },
+  totalLabel: {
+    color: '#FFFFFF',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  totalValue: {
+    color: '#FFFFFF',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  bottomBar: {
+    padding: 16,
+    backgroundColor: '#1A1A1A',
+  },
+  payButton: {
+    backgroundColor: '#6200EE',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  payButtonText: {
+    color: '#FFFFFF',
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  imageContainer: {
+    backgroundColor: '#a687c4',
+    borderRadius: 14,
+    padding: 4,
+    marginRight: 12,
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 2},
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    elevation: 3,
+  },
+  itemImage: {
+    width: 60,
+    height: 60,
+    borderRadius: 8,
+  },
+});
+
+export default PaymentScreen;


### PR DESCRIPTION
This commit introduces a new PaymentScreen component that allows users to select a payment method, view order details, and complete the payment process. The screen integrates with the existing CartContext to manage selected items and calculate the total cost, including tax and shipping. This feature enhances the checkout flow by providing a dedicated payment interface.